### PR TITLE
Logic bug in DNS checker

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -1913,7 +1913,7 @@ final class S3Request
 	*/
 	private function __dnsBucketName($bucket)
 	{
-		if (strlen($bucket) > 63 || !preg_match("/[^a-z0-9\.-]/", $bucket)) return false;
+		if (strlen($bucket) > 63 || preg_match("/[^a-z0-9\.-]/", $bucket)) return false;
 		if (strstr($bucket, '-.') !== false) return false;
 		if (strstr($bucket, '..') !== false) return false;
 		if (!preg_match("/^[0-9a-z]/", $bucket)) return false;


### PR DESCRIPTION
Using a simple bucket name caused the bucket name to be marked as non-DNS compatible.
