### PR TITLE
Enhancements to getAuthenticatedURL (allow response override headers, fixes for clock drift on short-expiry links)

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -990,7 +990,7 @@ class S3
 		} else {
 			$expires = time() + $lifetime;
 		}
-		$uri = str_replace('%2F', '/', rawurlencode($uri)); // URI should be encoded (thanks Sean O'Dea)
+		$uri = str_replace(array('%2F', '%2B'), array('/', '+'), rawurlencode($uri)); // URI should be encoded (thanks Sean O'Dea)
 				
 		$finalUrl = sprintf(($https ? 'https' : 'http').'://%s/%s?',
 		$hostBucket ? $bucket : $bucket.'.s3.amazonaws.com', $uri);


### PR DESCRIPTION
- Added a $headers argument that can take an assoociative array of response
  override headers (like content-disposition, etc.) Full AMZ documentation on
  the various options is at:
  http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectGET.html
- Added a getAWSSystemTime() method to poll AWS servers for their clock time.
  Used in the case of a short-expiry requests (< 120 seconds) which can be
  problematic on heavy-load shared servers due to clock drift. (Shockingly
  significant in some situations.)
- Added Date header to S3Response (needed by getAWSSystemTime())
