### PR TITLE
Only set the FOLLOWLOCATION curl opt if we are not in safe mode

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -1817,7 +1817,10 @@ final class S3Request
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
 		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, '__responseWriteCallback'));
 		curl_setopt($curl, CURLOPT_HEADERFUNCTION, array(&$this, '__responseHeaderCallback'));
-		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		if (!ini_get('safe_mode'))
+		{
+				curl_setopt($curl_handle, CURLOPT_FOLLOWLOCATION, true);
+		}
 
 		// Request types
 		switch ($this->verb)


### PR DESCRIPTION
This small patch allows the S3 library to be used in safe mode. Without this patch, it cannot be used in safe mode because the FOLLOWLOCATION curl opt is only allowed when not in safe mode.
