### PR TITLE
MIME type fix

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -1554,7 +1554,10 @@ class S3
 		$type = false;
 		// Fileinfo documentation says fileinfo_open() will use the
 		// MAGIC env var for the magic file
-		if (extension_loaded('fileinfo') && isset($_ENV['MAGIC']) &&
+		
+		$magic_works = !preg_match('/\.(css|js)$/i',$file);
+		
+		if ($magic_works && extension_loaded('fileinfo') && isset($_ENV['MAGIC']) &&
 		($finfo = finfo_open(FILEINFO_MIME, $_ENV['MAGIC'])) !== false)
 		{
 			if (($type = finfo_file($finfo, $file)) !== false)
@@ -1568,7 +1571,7 @@ class S3
 			finfo_close($finfo);
 
 		// If anyone is still using mime_content_type()
-		} elseif (function_exists('mime_content_type'))
+		} elseif ($magic_works && function_exists('mime_content_type'))
 			$type = trim(mime_content_type($file));
 
 		if ($type !== false && strlen($type) > 0) return $type;


### PR DESCRIPTION
finfo_file() doesn't detect mime types of CSS and JS files appropriately because of the lack of magic strings in those files. This fix disables finfo_file() and mime_content_type() when detecting mime types for CSS and JS files.
