### PR TITLE
 Improved compatibility with proprietary S3 services for bucket creation 

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -403,7 +403,7 @@ class S3
 	{
 		$rest = new S3Request('DELETE', $bucket, '', self::$endpoint);
 		$rest = $rest->getResponse();
-		if ($rest->error === false && $rest->code !== 204)
+		if ($rest->error === false && $rest->code !== 204 && $rest->code != 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
 		if ($rest->error !== false)
 		{

--- a/S3.php
+++ b/S3.php
@@ -654,7 +654,7 @@ class S3
 		if ($storageClass !== self::STORAGE_CLASS_STANDARD) // Storage class
 			$rest->setAmzHeader('x-amz-storage-class', $storageClass);
 		$rest->setAmzHeader('x-amz-acl', $acl);
-		$rest->setAmzHeader('x-amz-copy-source', sprintf('/%s/%s', $srcBucket, rawurlencode($srcUri)));
+		$rest->setAmzHeader('x-amz-copy-source', sprintf('/%s/%s', $srcBucket, $srcUri));
 		if (sizeof($requestHeaders) > 0 || sizeof($metaHeaders) > 0)
 			$rest->setAmzHeader('x-amz-metadata-directive', 'REPLACE');
 

--- a/S3.php
+++ b/S3.php
@@ -366,6 +366,7 @@ class S3
 	{
 		$rest = new S3Request('PUT', $bucket, '', self::$endpoint);
 		$rest->setAmzHeader('x-amz-acl', $acl);
+		$rest->setHeader('Content-Length', '0');
 
 		if ($location !== false)
 		{

--- a/S3.php
+++ b/S3.php
@@ -941,7 +941,7 @@ class S3
 	{
 		$rest = new S3Request('DELETE', $bucket, $uri, self::$endpoint);
 		$rest = $rest->getResponse();
-		if ($rest->error === false && $rest->code !== 204)
+		if ($rest->error === false && $rest->code !== 204 && $rest->code != 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
 		if ($rest->error !== false)
 		{


### PR DESCRIPTION
The S3-compatible service I was using was unable to create new buckets as the 'Content-Length' HTTP header was missing from the request.
