### PR TITLE
Wrong value set for CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -1809,7 +1809,7 @@ final class S3Request
 		if (S3::$useSSL)
 		{
 			// SSL Validation can now be optional for those with broken OpenSSL installations
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? 1 : 0);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? 2 : 0);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, S3::$useSSLValidation ? 1 : 0);
 
 			if (S3::$sslKey !== null) curl_setopt($curl, CURLOPT_SSLKEY, S3::$sslKey);


### PR DESCRIPTION
The correct value for CURLOPT_SSL_VERIFYHOST is 2, not 1.

From the libcurl documentation:

> When CURLOPT_SSL_VERIFYHOST is 2, that certificate must indicate that the
> server is the server to which you meant to connect, or the connection fails.
> 
> Curl considers the server the intended one when the Common Name field or a
> Subject Alternate Name field in the certificate matches the host name in the
> URL to which you told Curl to connect.
> 
> When the value is 1, the certificate must contain a Common Name field, but it
> doesn't matter what name it says. (This is not ordinarily a useful setting).

Reported by ghedo from debian.org - thank you.
