### PR TITLE
Enable server-side encryption when uploading a file

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -45,6 +45,9 @@ class S3
 	const STORAGE_CLASS_STANDARD = 'STANDARD';
 	const STORAGE_CLASS_RRS = 'REDUCED_REDUNDANCY';
 
+	const SSE_OFF = "";
+	const SSE_AES256 = "AES256";
+
 	private static $__accessKey = null; // AWS Access key
 	private static $__secretKey = null; // AWS Secret key
 	private static $__sslKey = null;
@@ -466,7 +469,7 @@ class S3
 	* @param constant $storageClass Storage class constant
 	* @return boolean
 	*/
-	public static function putObject($input, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $requestHeaders = array(), $storageClass = self::STORAGE_CLASS_STANDARD)
+	public static function putObject($input, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $requestHeaders = array(), $storageClass = self::STORAGE_CLASS_STANDARD, $serverSideEncryption = self::SSE_OFF)
 	{
 		if ($input === false) return false;
 		$rest = new S3Request('PUT', $bucket, $uri, self::$endpoint);
@@ -513,6 +516,9 @@ class S3
 
 		if ($storageClass !== self::STORAGE_CLASS_STANDARD) // Storage class
 			$rest->setAmzHeader('x-amz-storage-class', $storageClass);
+
+		if ($serverSideEncryption !== self::SSE_OFF) // Server-side Encryption
+			$rest->setAmzHeader('x-amz-server-side-encryption', $serverSideEncryption);
 
 		// We need to post with Content-Length and Content-Type, MD5 is optional
 		if ($rest->size >= 0 && ($rest->fp !== false || $rest->data !== false))


### PR DESCRIPTION
Added the option to specify a server-side encryption algorithm to use when Amazon S3 creates an object.

``` php
<?php
    require 'amazon-s3-php-class/S3.php';

    $fileName = "test-file.txt";
    $bucketName = "test-bucket";

    $s3 = new S3("ACCESS KEY", "SECRET KEY");
    $s3->putObject($s3->inputFile($fileName, false), $bucketName, $fileName, S3::ACL_PRIVATE, array(), array(), S3::STORAGE_CLASS_STANDARD, S3::SSE_AES256);
```

You just specify `S3::SSE_AES256` as the option for the new `$serverSideEncryption` parameter.

Then log into the S3 interface and check that `Details > Server Side Encryption` is set to AES-256.
