### PR TITLE
for compatibility with openstack swift s3 api(swift3)

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2251,6 +2251,10 @@ final class S3Request
 	*/
 	private function __dnsBucketName($bucket)
 	{
+ 		## FIXME
+ 		## FOR TEMP : no dns bucket support now ##
+ 		return false;
+
 		if (strlen($bucket) > 63 || preg_match("/[^a-z0-9\.-]/", $bucket) > 0) return false;
 		if (strstr($bucket, '-.') !== false) return false;
 		if (strstr($bucket, '..') !== false) return false;


### PR DESCRIPTION
We try to use amazon-s3-php-class as the php client for s3 like service whose backend is openstack swift(using swift3). It require the Content-length field or to throw out the 411 Length Required error. 

This pull request would solve above problem.
