### PR TITLE
Add support for getting only portions of objects via HTTP range requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Amazon S3 PHP Class
 
-
 ## Usage
 
 OO method (e,g; $s3->getObject(...)):

--- a/S3.php
+++ b/S3.php
@@ -330,7 +330,6 @@ class S3
 		if (self::$useExceptions)
 			throw new S3Exception($message, $file, $line, $code);
 		else
-echo "LINE $line\n";
 			trigger_error($message, E_USER_WARNING);
 	}
 
@@ -345,7 +344,7 @@ echo "LINE $line\n";
 	{
 		$rest = new S3Request('GET', '', '', self::$endpoint);
 		$rest = $rest->getResponse();
-		if ($rest->error === false && $rest->code != 200 )
+		if ($rest->error === false && $rest->code !== 200 )
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
 		if ($rest->error !== false)
 		{
@@ -721,11 +720,6 @@ echo "LINE $line\n";
 				$saveTo = $saveto_or_range;
 				$range = false;
 			}
-		}
-
-		if(isset($range) && (!is_array($range) || count($range) !=2)) {
-			echo "ERROR: INVALID HTTP RANGE!\n";
-			return false;
 		}
 
 		$rest = new S3Request('GET', $bucket, $uri, self::$endpoint, $range);


### PR DESCRIPTION
I made getObject() take a forth parameter.  Now the third or fourth parameter may be an array (the forth is an array if the third is a filename or resource).  If an array is passed in, then it should have two indices [0] and [1] which point to start and end bytes, respectively.

ie:
$first_ten_bytes = S3::getObject($bucketName, $uploadName, array(1,10));

Of course, if no range is passed in, then the whole object is retrieved.
