### PR TITLE
Fixed non-existent property "code" in response object (on failure) ..

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -431,7 +431,7 @@ class S3
 			$rest->setParameter('marker', $nextMarker);
 			if ($delimiter !== null && $delimiter !== '') $rest->setParameter('delimiter', $delimiter);
 
-			if (($response = $rest->getResponse()) == false || $response->code !== 200) break;
+			if (($response = $rest->getResponse()) == false || (isset($response->error) && isset($response->error->code))) break;
 
 			if (isset($response->body, $response->body->Contents))
 			foreach ($response->body->Contents as $c)


### PR DESCRIPTION
When I used invalidateDistribution(), calling this method caused Notice.
Reason is, StdClass with response does not contains property code (at least on request failure)..
