### PR TITLE
Handle open_basedir & safe mode for CURL

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2177,7 +2177,12 @@ final class S3Request
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
 		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, '__responseWriteCallback'));
 		curl_setopt($curl, CURLOPT_HEADERFUNCTION, array(&$this, '__responseHeaderCallback'));
-		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		
+		// Handle open_basedir & safe mode
+		if (!ini_get('safe_mode') && !ini_get('open_basedir'))
+		{
+			curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		}
 
 		// Request types
 		switch ($this->verb)


### PR DESCRIPTION
When safe_mode is enabled OR open_basedir is set, CURLOPT_FOLLOWLOCATION throws an error.
This fix is also in the official S3 SDK

Message: curl_setopt(): CURLOPT_FOLLOWLOCATION cannot be activated when
in safe_mode or an open_basedir is set
