### PR TITLE
Don't take curl callback by ref

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2303,8 +2303,8 @@ final class S3Request
 	/**
 	* CURL header callback
 	*
-	* @param resource &$curl CURL resource
-	* @param string &$data Data
+	* @param resource $curl CURL resource
+	* @param string $data Data
 	* @return integer
 	*/
 	private function __responseHeaderCallback($curl, $data)


### PR DESCRIPTION
Changing these does nothing to the caller, why would you take them by ref? HHVM doesn't promote this to refs if they can't be modified: https://github.com/facebook/hhvm/issues/2587
