### PR TITLE
Fix undefined index error when response body is null

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2278,7 +2278,10 @@ final class S3Request
 		if (in_array($this->response->code, array(200, 206)) && $this->fp !== false)
 			return fwrite($this->fp, $data);
 		else
-			$this->response->body .= $data;
+			if (isset($this->response->body))
+				$this->response->body .= $data;
+			else
+				$this->response->body = $data;
 		return strlen($data);
 	}
 


### PR DESCRIPTION
Noticed on PHP 5.5 that when S3 returns a null body, was getting this error:

`Error: Undefined property: stdClass::$body`

So I fixed it by checking that the `body` property is set before trying to append data to it.
