### PR TITLE
Add support for progress reports

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2351,8 +2351,13 @@ final class S3Request
 	 * This function handles curl progress reports and passes them to the
 	 * consumer
 	 */
-	private function _handleProgressReport($totalDownload, $downloaded, $totalUpload, $uploaded)
+	private function _handleProgressReport($ch = null, $totalDownload = 0, $downloaded = 0, $totalUpload = 0, $uploaded = 0)
 	{
+		if (!is_resource($ch)) {
+			list($totalDownload, $downloaded, $totalUpload, $uploaded) = func_get_args();
+			$ch = null;
+		}
+
 		if ($totalDownload > 0) {
 			return $this->_handleParsedProgressReport($totalDownload, $downloaded);
 		} else if ($totalUpload > 0) {

--- a/S3.php
+++ b/S3.php
@@ -1891,20 +1891,28 @@ class S3
 	 * @param  S3Request $client        The request to configure
 	 * @param  mixed     $configuration The configuration to parse
 	 */
-	private static function _configureProgressReports($client, $configuration = null) {
+	private static function _configureProgressReports($client, $configuration = null)
+	{
 
-		if (is_callable($configuration)) {
+		if (is_callable($configuration))
+		{
 			// If we've been passed just a callback
 			$configuration = array('callback' => $configuration);
-		} else if (!isset($configuration)) {
+		}
+		else if (!isset($configuration))
+		{
 			// If we've not been passed anything, make sure we're dealing with an array
 			$configuration = array();
-		} else if (is_array($configuration)) {	
-			if (!isset($configuration['callback']) && !isset($configuration['accuracy']) && count($configuration)) {
+		}
+		else if (is_array($configuration))
+		{	
+			if (!isset($configuration['callback']) && !isset($configuration['accuracy']) && count($configuration))
+			{
 				// If this is a list rather than a map, convert it to a map
 				$arr = array('callback' => $configuration[0]);
 
-				if (count($configuration) > 1) {
+				if (count($configuration) > 1)
+				{
 					$arr['accuracy'] = $configuration[1];
 				}
 
@@ -2352,10 +2360,15 @@ final class S3Request
 		}
 	}
 
-	private function _handleParsedProgressReport($total, $sofar) {
+	/**
+	 * This sends progress reports regardless of the current operation type
+	 */
+	private function _handleParsedProgressReport($total, $sofar)
+	{
 		$progress = $sofar / $total;
 
-		if ($progress - $this->lastReportedProgress > $this->progressReportAccuracy) {
+		if ($progress - $this->lastReportedProgress > $this->progressReportAccuracy)
+		{
 			$this->lastReportedProgress = $progress;
 
 			call_user_func($this->progressFunction, $progress);

--- a/S3.php
+++ b/S3.php
@@ -1887,13 +1887,10 @@ class S3
 	}
 
 	/**
-	 * Parse progress report configuration and pass it on to the client
-	 * @param  S3Request $client        The request to configure
+	 * Parse progress report configuration
 	 * @param  mixed     $configuration The configuration to parse
 	 */
-	private static function _configureProgressReports($client, $configuration = null)
-	{
-
+	public static function parseProgressReportConfig($configuration) {
 		if (is_callable($configuration))
 		{
 			// If we've been passed just a callback
@@ -1927,6 +1924,18 @@ class S3
 			'callback' => null,
 			'accuracy' => null
 		), $configuration);
+
+		return $configuration;
+	}
+
+	/**
+	 * Parse progress report configuration and pass it on to the client
+	 * @param  S3Request $client        The request to configure
+	 * @param  mixed     $configuration The configuration to parse
+	 */
+	private static function _configureProgressReports($client, $configuration = null)
+	{
+		$configuration = self::parseProgressReportConfig($configuration);
 
 		$client->configureProgressReporting($configuration['callback'], $configuration['accuracy']);
 	}


### PR DESCRIPTION
In this commit we've added support for progress reports (using the `CURLOPT_PROGRESSFUNCTION` option inside CURL). We've only added support to putObject and getObject. No one of their aliases will be able to use this functionality.

We've also added the ability to limit reports to a certain accuracy, so progress events are only reported to the consumer when their is enough difference between the current progress and the last report.
