### PR TITLE
Add default CURLOPT_TIMEOUT parameter.

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -172,6 +172,15 @@ class S3
 	 */
 	private static $__signingKeyResource = false;
 
+	/**
+	 * curl timeout
+	 *
+	 * @var int
+	 * @access public
+	 * @static
+	 */
+	public static $curlTimeout = 60;
+
 
 	/**
 	* Constructor - if you're not using the class statically
@@ -334,6 +343,16 @@ class S3
 	{
 		if (self::$__signingKeyResource !== false)
 			openssl_free_key(self::$__signingKeyResource);
+	}
+
+	/**
+	 * Sets the curl timeout from the default of 60 seconds (use 0 for no timeout)
+	 *
+	 * @return void
+	 */
+	public static function setTimeout($timeout)
+	{
+		self::$curlTimeout = $timeout;
 	}
 
 
@@ -2178,6 +2197,7 @@ final class S3Request
 		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, '__responseWriteCallback'));
 		curl_setopt($curl, CURLOPT_HEADERFUNCTION, array(&$this, '__responseHeaderCallback'));
 		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($curl, CURLOPT_TIMEOUT, S3::$curlTimeout);
 
 		// Request types
 		switch ($this->verb)


### PR DESCRIPTION
Without having CURLOPT_TIMEOUT set, any application using this library can build up a large number of open connections if S3 starts having issues.

It seems reasonable to have a default parameter that you can optionally override in order to prevent this situation from happening.
