### PR TITLE
Added initialize method for initiliazing S3 from a config file

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -190,6 +190,29 @@ class S3
 		self::$endpoint = $endpoint;
 	}
 
+	/**
+	 * Initializes S3 from a config file.
+	 * 
+	 * @param array configuration
+	 * @return void
+	 */
+	public function initialize($config) {
+		
+		// Load config file if config not defined.
+		if (empty($config)) {
+			get_instance()->config->load('s3', TRUE);
+			$config = get_instance()->config->item('s3');
+		}
+		
+		foreach ($config as $key => $val) {
+			if(!in_array($key, array('accessKey', 'secretKey'))) {
+				self::$$key = $val;
+			}
+		}
+		
+		if (isset($config["accessKey"]) && isset($config["secretKey"]))
+			self::setAuth($config["accessKey"], $config["secretKey"]);
+	}
 
 	/**
 	* Set the service endpoint


### PR DESCRIPTION
Added initialize method for initiliazing S3 from a config file.

Usage:
            $this->load->library('s3');
            $this->s3 = new s3();
            $this->s3->initialize($config); // Config can be a custom array. If null, config will be taken from config file.            

Sample config file: (to be placed under config/s3.php)

```
    <?php
    /*
    | -------------------------------------------------------------------
    | Amazon S3 Configuration
    | -------------------------------------------------------------------
    */

    $config["accessKey"] = "AKIAJHFQ7V53XXI5CYTA";
    $config["secretKey"] = "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";
    $config["useSSL"] = FALSE;
    $config["endpoint"] = 's3.amazonaws.com';
```
