### PR TITLE
Fixes stat cache issue from #89

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -561,6 +561,7 @@ class S3
 			self::__triggerError('S3::inputFile(): Unable to open input file: '.$file, __FILE__, __LINE__);
 			return false;
 		}
+        clearstatcache(false, $file);
 		return array('file' => $file, 'size' => filesize($file), 'md5sum' => $md5sum !== false ?
 		(is_string($md5sum) ? $md5sum : base64_encode(md5_file($file, true))) : '');
 	}
@@ -634,8 +635,10 @@ class S3
 		if (isset($input['size']) && $input['size'] >= 0)
 			$rest->size = $input['size'];
 		else {
-			if (isset($input['file']))
+			if (isset($input['file'])) {
+                clearstatcache(false, $input['file']);
 				$rest->size = filesize($input['file']);
+			}
 			elseif (isset($input['data']))
 				$rest->size = strlen($input['data']);
 		}

--- a/S3.php
+++ b/S3.php
@@ -561,7 +561,7 @@ class S3
 			self::__triggerError('S3::inputFile(): Unable to open input file: '.$file, __FILE__, __LINE__);
 			return false;
 		}
-        clearstatcache(false, $file);
+		clearstatcache(false, $file);
 		return array('file' => $file, 'size' => filesize($file), 'md5sum' => $md5sum !== false ?
 		(is_string($md5sum) ? $md5sum : base64_encode(md5_file($file, true))) : '');
 	}
@@ -636,7 +636,7 @@ class S3
 			$rest->size = $input['size'];
 		else {
 			if (isset($input['file'])) {
-                clearstatcache(false, $input['file']);
+				clearstatcache(false, $input['file']);
 				$rest->size = filesize($input['file']);
 			}
 			elseif (isset($input['data']))


### PR DESCRIPTION
filesize() may receive cached data, meaning the file size sent to AmazonS3 may be incorrect, so it's important to clear the cache before requesting the filesize.