### PR TITLE
added code to deal with bucket names that have a period in them with ssl

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2292,6 +2292,9 @@ final class S3Request
 	private function __dnsBucketName($bucket)
 	{
 		if (strlen($bucket) > 63 || preg_match("/[^a-z0-9\.-]/", $bucket) > 0) return false;
+		if(S3::$useSSL){ //using SSL, certs aren't valid for subdomains in new libcurl3
+			if (strstr($bucket, '.') !== false) return false;
+		}
 		if (strstr($bucket, '-.') !== false) return false;
 		if (strstr($bucket, '..') !== false) return false;
 		if (!preg_match("/^[0-9a-z]/", $bucket)) return false;


### PR DESCRIPTION
libcurl3 was updated and now get's upset if an SSL connection is made to a bucked with a "." in the name. (I.E. it doesn't want to automatically extend SSL authentication down to sub-domains anymore) 

This resolves the problem. 