### PR TITLE
Case in-sensitive header comparision

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2346,15 +2346,16 @@ final class S3Request
 			$data = trim($data);
 			if (strpos($data, ': ') === false) return $strlen;
 			list($header, $value) = explode(': ', $data, 2);
-			if ($header == 'Last-Modified')
+			$header = strtolower($header);
+			if ($header == 'last-modified')
 				$this->response->headers['time'] = strtotime($value);
-			elseif ($header == 'Date')
+			elseif ($header == 'date')
 				$this->response->headers['date'] = strtotime($value);
-			elseif ($header == 'Content-Length')
+			elseif ($header == 'content-length')
 				$this->response->headers['size'] = (int)$value;
-			elseif ($header == 'Content-Type')
+			elseif ($header == 'content-type')
 				$this->response->headers['type'] = $value;
-			elseif ($header == 'ETag')
+			elseif ($header == 'etag')
 				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
 				$this->response->headers[$header] = $value;


### PR DESCRIPTION
From RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1", Section 4.2, "Message Headers":

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

The updating RFC 7230 does not list any changes from RFC 2616 at this part.

Due it I can't work with e24files (e24cloud) which is a alternative s3 service. After that changes I can communicate freely with e24files if I setup endpoint.

Greetings,
