### PR TITLE
Added AWS v4 signature supports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Statically (e,g; S3::getObject(...)):
 S3::setAuth($awsAccessKey, $awsSecretKey);
 ```
 
+### AWS V4 Signature
+
+```php
+$s3->setSignatureVersion('v4);
+```
+Or statically
+```php
+S3::setSignatureVersion('v4');
+```
+
 ### Object Operations
 
 #### Uploading objects

--- a/README.md
+++ b/README.md
@@ -14,15 +14,6 @@ Statically (e,g; S3::getObject(...)):
 S3::setAuth($awsAccessKey, $awsSecretKey);
 ```
 
-### AWS V4 Signature
-
-```php
-$s3->setSignatureVersion('v4);
-```
-Or statically
-```php
-S3::setSignatureVersion('v4');
-```
 
 ### Object Operations
 

--- a/S3.php
+++ b/S3.php
@@ -1950,9 +1950,8 @@ class S3
 		$amzHeaders = array();
 		$amzRequests = array();
 		
-		$date = new DateTime( 'UTC' );
-		$amzDate =  $date->format( 'Ymd\THis\Z' );
-		$amzDateStamp = $date->format( 'Ymd' );
+		$amzDate =  gmdate( 'Ymd\THis\Z' );
+		$amzDateStamp = gmdate( 'Ymd' );
 
 		// amz-date ISO8601 format ? for aws request		
 		$amzHeaders['x-amz-date'] = $amzDate;

--- a/S3.php
+++ b/S3.php
@@ -206,7 +206,6 @@ class S3
 	* @param string $secretKey Secret key
 	* @param boolean $useSSL Enable SSL
 	* @param string $endpoint Amazon URI
-	* @param string $region Bucket Region
 	* @return void
 	*/
 	public function __construct($accessKey = null, $secretKey = null, $useSSL = false, $endpoint = 's3.amazonaws.com')

--- a/S3.php
+++ b/S3.php
@@ -1984,10 +1984,9 @@ class S3
 	* @param string $method 
 	* @param string $uri
 	* @param string $data
-	* @param array $parameters
 	* @return array $headers
 	*/
-	public static function __getSignatureV4($aHeaders, $headers, $method='GET', $uri='', $data = '', $parameters=array())
+	public static function __getSignatureV4($aHeaders, $headers, $method='GET', $uri='', $data = '')
 	{		
 		$service = 's3';
 		$region = S3::getRegion();
@@ -2014,10 +2013,17 @@ class S3
 		// payload
 		$payloadHash = isset($amzHeaders['x-amz-content-sha256']) ? $amzHeaders['x-amz-content-sha256'] :  hash('sha256', $data);
 
+		// parameters
+		$parameters = array();
+		if (strpos($uri, '?')) {
+			list ($uri, $query_str) = @explode("?", $uri);
+			parse_str($query_str, $parameters);
+		}
+
 		// CanonicalRequests
 		$amzRequests[] = $method;
 		$amzRequests[] = $uri;
-		$amzRequests[] = http_build_query($parameters);		
+		$amzRequests[] = http_build_query($parameters);
 		// add header as string to requests
 		foreach ( $amzHeaders as $k => $v ) {
 			$amzRequests[] = $k . ':' . $v;
@@ -2372,8 +2378,7 @@ final class S3Request
 						$this->headers, 
 						$this->verb, 
 						$this->uri,
-						$this->data,
-						$this->parameters
+						$this->data
 					);
 					foreach ($amzHeaders as $k => $v) {
 						$headers[] = $k .': '. $v;

--- a/S3.php
+++ b/S3.php
@@ -585,7 +585,7 @@ class S3
 
 		if ($location === false) $location = self::getRegion();
 
-		if ($location !== false)
+		if ($location !== false && $location !== "us-east-1")
 		{
 			$dom = new DOMDocument;
 			$createBucketConfiguration = $dom->createElement('CreateBucketConfiguration');
@@ -1776,11 +1776,13 @@ class S3
 		if ($comment !== '') $distributionConfig->appendChild($dom->createElement('Comment', $comment));
 		$distributionConfig->appendChild($dom->createElement('Enabled', $enabled ? 'true' : 'false'));
 
-		$trusted = $dom->createElement('TrustedSigners');
-		foreach ($trustedSigners as $id => $type)
-			$trusted->appendChild($id !== '' ? $dom->createElement($type, $id) : $dom->createElement($type));
-		$distributionConfig->appendChild($trusted);
-
+		if (!empty($trustedSigners))
+		{
+			$trusted = $dom->createElement('TrustedSigners');
+			foreach ($trustedSigners as $id => $type)
+				$trusted->appendChild($id !== '' ? $dom->createElement($type, $id) : $dom->createElement($type));
+			$distributionConfig->appendChild($trusted);
+		}
 		$dom->appendChild($distributionConfig);
 		//var_dump($dom->saveXML());
 		return $dom->saveXML();
@@ -2022,7 +2024,8 @@ class S3
 
 		// CanonicalRequests
 		$amzRequests[] = $method;
-		$amzRequests[] = $uri;
+		$uriQmPos = strpos($uri, '?'); 
+		$amzRequests[] = ($uriQmPos === false ? $uri : substr($uri, 0, $uriQmPos));
 		$amzRequests[] = http_build_query($parameters);
 		// add header as string to requests
 		foreach ( $amzHeaders as $k => $v ) {

--- a/S3.php
+++ b/S3.php
@@ -190,6 +190,14 @@ class S3
 	 */
 	private static $__signingKeyResource = false;
 
+	/**
+	 * AWS Signature Version
+	 *
+	 * @var string
+	 * @acess public
+	 * @static
+	 */
+	public static $signVer = 'v2';
 
 	/**
 	* Constructor - if you're not using the class statically
@@ -198,6 +206,7 @@ class S3
 	* @param string $secretKey Secret key
 	* @param boolean $useSSL Enable SSL
 	* @param string $endpoint Amazon URI
+	* @param string $region Bucket Region
 	* @return void
 	*/
 	public function __construct($accessKey = null, $secretKey = null, $useSSL = false, $endpoint = 's3.amazonaws.com')
@@ -341,6 +350,18 @@ class S3
 		file_get_contents($signingKey) : $signingKey)) !== false) return true;
 		self::__triggerError('S3::setSigningKey(): Unable to open load private key: '.$signingKey, __FILE__, __LINE__);
 		return false;
+	}
+
+
+	/**
+	* Set Signature Version
+	*
+	* @param string $version of signature ('v4' or 'v2')
+	* @return void
+	*/
+	public static function setSignatureVersion($version = 'v2')
+	{
+		self::$signVer = $version;
 	}
 
 
@@ -583,7 +604,7 @@ class S3
 		}
 		clearstatcache(false, $file);
 		return array('file' => $file, 'size' => filesize($file), 'md5sum' => $md5sum !== false ?
-		(is_string($md5sum) ? $md5sum : base64_encode(md5_file($file, true))) : '');
+		(is_string($md5sum) ? $md5sum : base64_encode(md5_file($file, true))) : '', 'sha256sum' => hash_file('sha256', $file));
 	}
 
 
@@ -640,7 +661,8 @@ class S3
 
 		if (!is_array($input)) $input = array(
 			'data' => $input, 'size' => strlen($input),
-			'md5sum' => base64_encode(md5($input, true))
+			'md5sum' => base64_encode(md5($input, true)),
+			'sha256sum' => hash('sha256', $input)
 		);
 
 		// Data
@@ -692,6 +714,8 @@ class S3
 		{
 			$rest->setHeader('Content-Type', $input['type']);
 			if (isset($input['md5sum'])) $rest->setHeader('Content-MD5', $input['md5sum']);
+
+			if (isset($input['sha256sum'])) $rest->setAmzHeader('x-amz-content-sha256', $input['sha256sum']);
 
 			$rest->setAmzHeader('x-amz-acl', $acl);
 			foreach ($metaHeaders as $h => $v) $rest->setAmzHeader('x-amz-meta-'.$h, $v);
@@ -1907,6 +1931,105 @@ class S3
 		(str_repeat(chr(0x36), 64))) . $string)))));
 	}
 
+
+	/**
+	* Generate the headers for AWS Signature V4
+	* @internal Used by S3Request::getResponse()
+	* @param array $aheaders amzHeaders 
+	* @param array $headers
+	* @param string $method 
+	* @param string $uri
+	* @param array $parameters
+	* @return array $headers
+	*/
+	public static function __getSignatureV4($aHeaders, $headers, $method='GET', $uri='', $parameters=array())
+	{
+		// calculate the service name and region from the endpoint hostname: dynamodb.us-east-1.amazonaws.com
+		list( $service, $region, $junk ) = explode( '.', self::$endpoint );
+		
+		$algorithm = 'AWS4-HMAC-SHA256';
+		$amzHeaders = array();
+		$amzRequests = array();
+		
+		$date = new DateTime( 'UTC' );
+		$amzDate =  $date->format( 'Ymd\THis\Z' );
+		$amzDateStamp = $date->format( 'Ymd' );
+
+		// amz-date ISO8601 format ? for aws request		
+		$amzHeaders['x-amz-date'] = $amzDate;
+
+		// CanonicalHeaders
+		foreach ( $headers as $k => $v ) {
+			$amzHeaders[ strtolower( $k ) ] = trim( $v );
+		} 
+		foreach ( $aHeaders as $k => $v ) {
+			$amzHeaders[ strtolower( $k ) ] = trim( $v );
+		} 
+		uksort( $amzHeaders, 'strcmp' );
+
+		// payload
+		$payloadHash = isset($amzHeaders['x-amz-content-sha256']) ? $amzHeaders['x-amz-content-sha256'] :  hash('sha256', '');
+
+		// CanonicalRequests
+		$amzRequests[] = $method;
+		$amzRequests[] = $uri;
+		$amzRequests[] = http_build_query($parameters);		
+		// add header as string to requests
+		foreach ( $amzHeaders as $k => $v ) {
+			$amzRequests[] = $k . ':' . $v;
+		}
+		// add a blank entry so we end up with an extra line break
+		$amzRequests[] = '';
+		// SignedHeaders
+		$amzRequests[] = implode( ';', array_keys( $amzHeaders ) );
+		// payload hash
+		$amzRequests[] = $payloadHash;
+		// request as string
+		$amzRequestStr = implode("\n", $amzRequests);
+		
+		// CredentialScope
+		$credentialScope = array();
+		$credentialScope[] = $amzDateStamp;
+		$credentialScope[] = $region;
+		$credentialScope[] = $service;
+		$credentialScope[] = 'aws4_request';
+
+		// stringToSign
+		$stringToSign = array();
+		$stringToSign[] = $algorithm;
+		$stringToSign[] = $amzDate;
+		$stringToSign[] = implode('/', $credentialScope);
+		$stringToSign[] =  hash('sha256', $amzRequestStr);
+		// as string
+		$stringToSignStr = implode("\n", $stringToSign);
+
+		// Make Signature
+		$kSecret = 'AWS4' . self::$__secretKey;
+		$kDate = hash_hmac( 'sha256', $amzDateStamp, $kSecret, true );
+		$kRegion = hash_hmac( 'sha256', $region, $kDate, true );
+		$kService = hash_hmac( 'sha256', $service, $kRegion, true );
+		$kSigning = hash_hmac( 'sha256', 'aws4_request', $kService, true );
+		
+		$signature = hash_hmac( 'sha256', $stringToSignStr, $kSigning );
+
+		$authorization = array(
+			'Credential=' . self::$__accessKey . '/' . implode( '/', $credentialScope ),
+			'SignedHeaders=' . implode( ';', array_keys( $amzHeaders ) ),
+			'Signature=' . $signature,
+		);
+
+		$authorizationStr = $algorithm . ' ' . implode( ',', $authorization );
+
+		$resultHeaders = array( 
+			'X-AMZ-DATE' => $amzDate,			
+			'Authorization' => $authorizationStr
+		);
+		if (!isset($aHeaders['x-amz-content-sha256'])) $resultHeaders['x-amz-content-sha256'] = $payloadHash;
+
+		return $resultHeaders;
+	}
+
+
 }
 
 /**
@@ -2190,13 +2313,27 @@ final class S3Request
 				$headers[] = 'Authorization: ' . S3::__getSignature($this->headers['Date']);
 			else
 			{
-				$headers[] = 'Authorization: ' . S3::__getSignature(
-					$this->verb."\n".
-					$this->headers['Content-MD5']."\n".
-					$this->headers['Content-Type']."\n".
-					$this->headers['Date'].$amz."\n".
-					$this->resource
-				);
+				if (S3::$signVer == 'v2')
+				{
+					$headers[] = 'Authorization: ' . S3::__getSignature(
+						$this->verb."\n".
+						$this->headers['Content-MD5']."\n".
+						$this->headers['Content-Type']."\n".
+						$this->headers['Date'].$amz."\n".
+						$this->resource
+					);
+				} else {
+					$amzHeaders = S3::__getSignatureV4(
+						$this->amzHeaders,
+						$this->headers, 
+						$this->verb, 
+						$this->uri,
+						$this->parameters
+					);
+					foreach ($amzHeaders as $k => $v) {
+						$headers[] = $k .': '. $v;
+					}
+				}
 			}
 		}
 

--- a/S3.php
+++ b/S3.php
@@ -200,13 +200,13 @@ class S3
 	private static $__signingKeyResource = false;
 
 	/**
-	 * AWS Signature Version
+	 * CURL progress function callback 
 	 *
-	 * @var string
-	 * @acess public
-	 * @static
+	 * @var function
+	 * @access public
+	 * @static 
 	 */
-	public static $signVer = 'v2';
+	public static $progressFunction = null;
 
 	/**
 	* Constructor - if you're not using the class statically
@@ -262,8 +262,11 @@ class S3
 		$region = self::$region;
 
 		// parse region from endpoint if not specific
-		if (empty($region)) {
-			if (preg_match("/s3[.-](?:website-|dualstack\.)?(.+)\.amazonaws\.com/i",self::$endpoint,$match) !== 0 && strtolower($match[1]) !== "external-1") {
+		if (empty($region)) 
+		{
+			if (preg_match("/s3[.-](?:website-|dualstack\.)?(.+)\.amazonaws\.com/i", self::$endpoint, $match) !== 0 
+			&& strtolower($match[1]) !== "external-1") 
+			{
 				$region = $match[1];
 			}		
 		}
@@ -395,17 +398,6 @@ class S3
 	}
 
 
-	/**
-	* Set Signature Version
-	*
-	* @param string $version of signature ('v4' or 'v2')
-	* @return void
-	*/
-	public static function setSignatureVersion($version = 'v2')
-	{
-		self::$signVer = $version;
-	}
-
 
 	/**
 	* Free signing key from memory, MUST be called if you are using setSigningKey()
@@ -416,6 +408,17 @@ class S3
 	{
 		if (self::$__signingKeyResource !== false)
 			openssl_free_key(self::$__signingKeyResource);
+	}
+
+	/**
+	* Set progress function
+	*
+	* @param function $func Progress function 
+	* @return void
+	*/
+	public static function setProgressFunction($func = null)
+	{
+		self::$progressFunction = $func;
 	}
 
 
@@ -1980,109 +1983,100 @@ class S3
 
 	/**
 	* Generate the headers for AWS Signature V4
+	* 
 	* @internal Used by S3Request::getResponse()
-	* @param array $aheaders amzHeaders 
+	* @param array $amzHeaders
 	* @param array $headers
-	* @param string $method 
+	* @param string $method
 	* @param string $uri
-	* @param string $data
-	* @return array $headers
+	* @param array $parameters
+	* @return array
 	*/
-	public static function __getSignatureV4($aHeaders, $headers, $method='GET', $uri='', $data = '')
+	public static function __getSignatureV4($amzHeaders, $headers, $method, $uri, $parameters)
 	{		
 		$service = 's3';
 		$region = S3::getRegion();
-		
-		$algorithm = 'AWS4-HMAC-SHA256';
-		$amzHeaders = array();
-		$amzRequests = array();
-		
-		$amzDate =  gmdate( 'Ymd\THis\Z' );
-		$amzDateStamp = gmdate( 'Ymd' );
 
-		// amz-date ISO8601 format ? for aws request		
-		$amzHeaders['x-amz-date'] = $amzDate;
+		$algorithm = 'AWS4-HMAC-SHA256';
+		$combinedHeaders = array();
+
+		$amzDateStamp = substr($amzHeaders['x-amz-date'], 0, 8);
 
 		// CanonicalHeaders
-		foreach ( $headers as $k => $v ) {
-			$amzHeaders[ strtolower( $k ) ] = trim( $v );
-		} 
-		foreach ( $aHeaders as $k => $v ) {
-			$amzHeaders[ strtolower( $k ) ] = trim( $v );
-		} 
-		uksort( $amzHeaders, 'strcmp' );
+		foreach ($headers as $k => $v)
+			$combinedHeaders[strtolower($k)] = trim($v);
+		foreach ($amzHeaders as $k => $v) 
+			$combinedHeaders[strtolower($k)] = trim($v);
+		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));
 
-		// payload
-		$payloadHash = isset($amzHeaders['x-amz-content-sha256']) ? $amzHeaders['x-amz-content-sha256'] :  hash('sha256', $data);
+		// Convert null query string parameters to strings and sort
+		$parameters = array_map('strval', $parameters); 
+		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
+		$queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
 
-		// parameters
-		$parameters = array();
-		if (strpos($uri, '?')) {
-			list ($uri, $query_str) = @explode("?", $uri);
-			parse_str($query_str, $parameters);
-		}
+		// Payload
+		$amzPayload = array($method);
 
-		// CanonicalRequests
-		$amzRequests[] = $method;
-		$uriQmPos = strpos($uri, '?'); 
-		$amzRequests[] = ($uriQmPos === false ? $uri : substr($uri, 0, $uriQmPos));
-		$amzRequests[] = http_build_query($parameters);
+		$qsPos = strpos($uri, '?');
+		$amzPayload[] = ($qsPos === false ? $uri : substr($uri, 0, $qsPos));
+
+		$amzPayload[] = $queryString;
 		// add header as string to requests
-		foreach ( $amzHeaders as $k => $v ) {
-			$amzRequests[] = $k . ':' . $v;
+		foreach ($combinedHeaders as $k => $v ) 
+		{
+			$amzPayload[] = $k . ':' . $v;
 		}
 		// add a blank entry so we end up with an extra line break
-		$amzRequests[] = '';
+		$amzPayload[] = '';
 		// SignedHeaders
-		$amzRequests[] = implode( ';', array_keys( $amzHeaders ) );
+		$amzPayload[] = implode(';', array_keys($combinedHeaders));
 		// payload hash
-		$amzRequests[] = $payloadHash;
+		$amzPayload[] = $amzHeaders['x-amz-content-sha256'];
 		// request as string
-		$amzRequestStr = implode("\n", $amzRequests);
-		
+		$amzPayloadStr = implode("\n", $amzPayload);
+
 		// CredentialScope
-		$credentialScope = array();
-		$credentialScope[] = $amzDateStamp;
-		$credentialScope[] = $region;
-		$credentialScope[] = $service;
-		$credentialScope[] = 'aws4_request';
+		$credentialScope = array($amzDateStamp, $region, $service, 'aws4_request');
 
 		// stringToSign
-		$stringToSign = array();
-		$stringToSign[] = $algorithm;
-		$stringToSign[] = $amzDate;
-		$stringToSign[] = implode('/', $credentialScope);
-		$stringToSign[] =  hash('sha256', $amzRequestStr);
-		// as string
-		$stringToSignStr = implode("\n", $stringToSign);
+		$stringToSignStr = implode("\n", array($algorithm, $amzHeaders['x-amz-date'], 
+		implode('/', $credentialScope), hash('sha256', $amzPayloadStr)));
 
 		// Make Signature
 		$kSecret = 'AWS4' . self::$__secretKey;
-		$kDate = hash_hmac( 'sha256', $amzDateStamp, $kSecret, true );
-		$kRegion = hash_hmac( 'sha256', $region, $kDate, true );
-		$kService = hash_hmac( 'sha256', $service, $kRegion, true );
-		$kSigning = hash_hmac( 'sha256', 'aws4_request', $kService, true );
-		
-		$signature = hash_hmac( 'sha256', $stringToSignStr, $kSigning );
+		$kDate = hash_hmac('sha256', $amzDateStamp, $kSecret, true);
+		$kRegion = hash_hmac('sha256', $region, $kDate, true);
+		$kService = hash_hmac('sha256', $service, $kRegion, true);
+		$kSigning = hash_hmac('sha256', 'aws4_request', $kService, true);
 
-		$authorization = array(
-			'Credential=' . self::$__accessKey . '/' . implode( '/', $credentialScope ),
-			'SignedHeaders=' . implode( ';', array_keys( $amzHeaders ) ),
+		$signature = hash_hmac('sha256', $stringToSignStr, $kSigning);
+
+		return $algorithm . ' ' . implode(',', array(
+			'Credential=' . self::$__accessKey . '/' . implode('/', $credentialScope),
+			'SignedHeaders=' . implode(';', array_keys($combinedHeaders)),
 			'Signature=' . $signature,
-		);
-
-		$authorizationStr = $algorithm . ' ' . implode( ',', $authorization );
-
-		$resultHeaders = array( 
-			'X-AMZ-DATE' => $amzDate,			
-			'Authorization' => $authorizationStr
-		);
-		if (!isset($aHeaders['x-amz-content-sha256'])) $resultHeaders['x-amz-content-sha256'] = $payloadHash;
-
-		return $resultHeaders;
+		));
 	}
 
 
+	/**
+	* Sort compare for meta headers
+	*
+	* @internal Used to sort x-amz meta headers
+	* @param string $a String A
+	* @param string $b String B
+	* @return integer
+	*/
+	private static function __sortMetaHeadersCmp($a, $b)
+	{
+		$lenA = strlen($a);
+		$lenB = strlen($b);
+		$minLen = min($lenA, $lenB);
+		$ncmp = strncmp($a, $b, $minLen);
+		if ($lenA == $lenB) return $ncmp;
+		if (0 == $ncmp) return $lenA < $lenB ? -1 : 1;
+		return $ncmp;
+	}
 }
 
 /**
@@ -2203,16 +2197,10 @@ final class S3Request
 	*/
 	function __construct($verb, $bucket = '', $uri = '', $endpoint = 's3.amazonaws.com')
 	{
-		
 		$this->endpoint = $endpoint;
 		$this->verb = $verb;
 		$this->bucket = $bucket;
 		$this->uri = $uri !== '' ? '/'.str_replace('%2F', '/', rawurlencode($uri)) : '/';
-
-		//if ($this->bucket !== '')
-		//	$this->resource = '/'.$this->bucket.$this->uri;
-		//else
-		//	$this->resource = $this->uri;
 
 		if ($this->bucket !== '')
 		{
@@ -2223,6 +2211,7 @@ final class S3Request
 			}
 			else
 			{
+				// Old format, deprecated by AWS - removal scheduled for September 30th, 2020
 				$this->headers['Host'] = $this->endpoint;
 				$this->uri = $this->uri;
 				if ($this->bucket !== '') $this->uri = '/'.$this->bucket.$this->uri;
@@ -2310,8 +2299,6 @@ final class S3Request
 		}
 		$url = (S3::$useSSL ? 'https://' : 'http://') . ($this->headers['Host'] !== '' ? $this->headers['Host'] : $this->endpoint) . $this->uri;
 
-		//var_dump('bucket: ' . $this->bucket, 'uri: ' . $this->uri, 'resource: ' . $this->resource, 'url: ' . $url);
-
 		// Basic setup
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_USERAGENT, 'S3/php');
@@ -2341,56 +2328,46 @@ final class S3Request
 		}
 
 		// Headers
-		$headers = array(); $amz = array();
-		foreach ($this->amzHeaders as $header => $value)
-			if (strlen($value) > 0) $headers[] = $header.': '.$value;
-		foreach ($this->headers as $header => $value)
-			if (strlen($value) > 0) $headers[] = $header.': '.$value;
-
-		// Collect AMZ headers for signature
-		foreach ($this->amzHeaders as $header => $value)
-			if (strlen($value) > 0) $amz[] = strtolower($header).':'.$value;
-
-		// AMZ headers must be sorted
-		if (sizeof($amz) > 0)
-		{
-			//sort($amz);
-			usort($amz, array(&$this, '__sortMetaHeadersCmp'));
-			$amz = "\n".implode("\n", $amz);
-		} else $amz = '';
-
+		$httpHeaders = array(); 
 		if (S3::hasAuth())
 		{
 			// Authorization string (CloudFront stringToSign should only contain a date)
 			if ($this->headers['Host'] == 'cloudfront.amazonaws.com')
-				$headers[] = 'Authorization: ' . S3::__getSignature($this->headers['Date']);
+			{
+				# TODO: Update CloudFront authentication
+				foreach ($this->amzHeaders as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				foreach ($this->headers as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				$httpHeaders[] = 'Authorization: ' . S3::__getSignature($this->headers['Date']);
+			}
 			else
 			{
-				if (S3::$signVer == 'v2')
-				{
-					$headers[] = 'Authorization: ' . S3::__getSignature(
-						$this->verb."\n".
-						$this->headers['Content-MD5']."\n".
-						$this->headers['Content-Type']."\n".
-						$this->headers['Date'].$amz."\n".
-						$this->resource
-					);
-				} else {
-					$amzHeaders = S3::__getSignatureV4(
-						$this->amzHeaders,
-						$this->headers, 
-						$this->verb, 
-						$this->uri,
-						$this->data
-					);
-					foreach ($amzHeaders as $k => $v) {
-						$headers[] = $k .': '. $v;
-					}
-				}
+				$this->amzHeaders['x-amz-date'] = gmdate('Ymd\THis\Z');
+
+				if (!isset($this->amzHeaders['x-amz-content-sha256'])) 
+					$this->amzHeaders['x-amz-content-sha256'] = hash('sha256', $this->data);
+
+				foreach ($this->amzHeaders as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				foreach ($this->headers as $header => $value)
+					if (strlen($value) > 0) $httpHeaders[] = $header.': '.$value;
+
+				$httpHeaders[] = 'Authorization: ' . S3::__getSignatureV4(
+					$this->amzHeaders,
+					$this->headers, 
+					$this->verb, 
+					$this->uri,
+					$this->parameters
+				);
+
 			}
 		}
 
-		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $httpHeaders);
 		curl_setopt($curl, CURLOPT_HEADER, false);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
 		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, '__responseWriteCallback'));
@@ -2425,6 +2402,12 @@ final class S3Request
 				curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
 			break;
 			default: break;
+		}
+
+		// set curl progress function callback
+		if (S3::$progressFunction) {
+			curl_setopt($curl, CURLOPT_NOPROGRESS, false);
+			curl_setopt($curl, CURLOPT_PROGRESSFUNCTION, S3::$progressFunction);
 		}
 
 		// Execute, grab errors
@@ -2465,24 +2448,6 @@ final class S3Request
 		return $this->response;
 	}
 
-	/**
-	* Sort compare for meta headers
-	*
-	* @internal Used to sort x-amz meta headers
-	* @param string $a String A
-	* @param string $b String B
-	* @return integer
-	*/
-	private function __sortMetaHeadersCmp($a, $b)
-	{
-		$lenA = strpos($a, ':');
-		$lenB = strpos($b, ':');
-		$minLen = min($lenA, $lenB);
-		$ncmp = strncmp($a, $b, $minLen);
-		if ($lenA == $lenB) return $ncmp;
-		if (0 == $ncmp) return $lenA < $lenB ? -1 : 1;
-		return $ncmp;
-	}
 
 	/**
 	* CURL write callback

--- a/example.php
+++ b/example.php
@@ -35,9 +35,6 @@ if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
 // Instantiate the class
 $s3 = new S3(awsAccessKey, awsSecretKey);
 
-// using v4 signature
-$s3->setSignatureVersion('v4');
-
 // List your buckets:
 echo "S3::listBuckets(): ".print_r($s3->listBuckets(), 1)."\n";
 

--- a/example.php
+++ b/example.php
@@ -35,6 +35,9 @@ if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
 // Instantiate the class
 $s3 = new S3(awsAccessKey, awsSecretKey);
 
+// using v4 signature
+$s3->setSignatureVersion('v4');
+
 // List your buckets:
 echo "S3::listBuckets(): ".print_r($s3->listBuckets(), 1)."\n";
 


### PR DESCRIPTION
Just Added AWS v4 signature supports.

Using 'AWS4-HMAC-SHA256' for  authorization. 

For backward compatible , you must calling `$s3->setSignatureVersion('v4')` or `S3::setSignatureVersion('v4')` before requests.

Only tested at `China Beijing` region, i think `Franckfurt` should be okay too.

ref: #120, #96    