### PR TITLE
Make hostname and credentials customisable per request

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,6 @@
 /example-form.php export-ignore
 /example-wrapper.php export-ignore
 /example-helpers.php export-ignore
+/example-custom-endpoint.php export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/README.md export-ignore
+/example.php export-ignore
+/example-cloudfront.php export-ignore
+/example-form.php export-ignore
+/example-wrapper.php export-ignore
+/example-helpers.php export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor/
+/composer.lock
+/composer.phar

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+BSD 2-Clause License
+
+Copyright (c) 2013, Donovan Schönknecht
+Copyright (c) 2019, Red Matter
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/S3.php
+++ b/S3.php
@@ -2001,7 +2001,7 @@ class S3
 	/**
 	* Get the current time
 	*
-	* @internal Used to apply offsets to sytem time
+	* @internal Used to apply offsets to system time
 	* @return integer
 	*/
 	public static function __getTime()

--- a/S3.php
+++ b/S3.php
@@ -49,6 +49,9 @@ class S3
 	const SSE_NONE = '';
 	const SSE_AES256 = 'AES256';
 
+	const SigV2 = 'sigv2';
+	const SigV4 = 'sigv4';
+
 	/**
 	 * Default credentials to access AWS
 	 *
@@ -2410,7 +2413,7 @@ final class S3Request
 		if (S3::hasAuth())
 		{
 			// Authorization string (CloudFront stringToSign should only contain a date)
-			if ($this->headers['Host'] === 'cloudfront.amazonaws.com')
+			if ($this->endpoint->signatureVersion === S3::SigV2 || $this->headers['Host'] === 'cloudfront.amazonaws.com')
 			{
 				# TODO: Update CloudFront authentication
 				foreach ($this->amzHeaders as $header => $value)
@@ -2632,6 +2635,13 @@ final class EndpointConfig
 	const DEFAULT_HOST = 's3.amazonaws.com';
 
 	/**
+	 * Auth signature version
+	 *
+	 * @var string
+	 */
+	public $signatureVersion = S3::SigV4;
+
+	/**
 	 * Enable SSL
 	 *
 	 * @var bool
@@ -2725,6 +2735,12 @@ final class EndpointConfig
 	public function withSSLVersion($sslVersion = CURL_SSLVERSION_TLSv1)
 	{
 		$this->useSSLVersion = $sslVersion;
+		return $this;
+	}
+
+	public function withSignatureVersion($version = S3::SigV4)
+	{
+		$this->signatureVersion = $version;
 		return $this;
 	}
 

--- a/S3.php
+++ b/S3.php
@@ -624,7 +624,6 @@ class S3
 			}
 		}
 
-		$endpoint = self::getEndpoint($endpoint);
 		$rest = new S3Request('PUT', new BucketConfig($bucket, $endpoint->defaultRegion), '', $endpoint);
 		$rest->setAmzHeader('x-amz-acl', $acl);
 
@@ -2373,8 +2372,8 @@ final class S3Request
 			curl_setopt($curl, CURLOPT_SSLVERSION, $this->endpoint->useSSLVersion);
 
 			// SSL Validation can now be optional for those with broken OpenSSL installations
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::getEndpoint()->useSSLValidation ? 2 : 0);
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, S3::getEndpoint()->useSSLValidation ? 1 : 0);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->endpoint->useSSLValidation ? 2 : 0);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->endpoint->useSSLValidation ? 1 : 0);
 
 			if ($this->endpoint->sslKey !== null) curl_setopt($curl, CURLOPT_SSLKEY, $this->endpoint->sslKey);
 			if ($this->endpoint->sslCert !== null) curl_setopt($curl, CURLOPT_SSLCERT, $this->endpoint->sslCert);

--- a/S3.php
+++ b/S3.php
@@ -2034,11 +2034,16 @@ class S3
 	*/
 	private static function __getHash($string)
 	{
-		return base64_encode(extension_loaded('hash') ?
-		hash_hmac('sha1', $string, self::getSecretKey(), true) : pack('H*', sha1(
-		(str_pad(self::getSecretKey(), 64, chr(0x00)) ^ (str_repeat(chr(0x5c), 64))) .
-		pack('H*', sha1((str_pad(self::getSecretKey(), 64, chr(0x00)) ^
-		(str_repeat(chr(0x36), 64))) . $string)))));
+		if (extension_loaded('hash')) {
+			return base64_encode(
+				hash_hmac('sha1', $string, self::getSecretKey(), true));
+		}
+
+		return base64_encode(
+			pack('H*', sha1(
+				(str_pad(self::getSecretKey(), 64, chr(0x00)) ^ str_repeat(chr(0x5c), 64)) .
+				pack('H*', sha1(
+					(str_pad(self::getSecretKey(), 64, chr(0x00)) ^ str_repeat(chr(0x36), 64)) . $string)))));
 	}
 
 

--- a/S3.php
+++ b/S3.php
@@ -614,6 +614,8 @@ class S3
 	 */
 	public static function putBucket($bucket, $acl = self::ACL_PRIVATE, $location = false, EndpointConfig $endpoint = null)
 	{
+		$endpoint = self::getEndpoint($endpoint);
+
 		if ($location === false)
 		{
 			$location = self::getRegion($endpoint);

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     },
     "autoload": {
         "classmap": ["S3.php"]
+    },
+    "autoload-dev": {
+        "files": ["example-helpers.php"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,13 @@
         }
     ],
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=5.2.0",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-openssl": "*",
+        "ext-json": "*",
+        "ext-simplexml": "*",
+        "ext-fileinfo": "*"
     },
     "autoload": {
         "classmap": ["S3.php"]

--- a/example-cloudfront.php
+++ b/example-cloudfront.php
@@ -6,24 +6,18 @@
 * S3 class - CloudFront usage
 */
 
-if (!class_exists('S3')) require_once 'S3.php';
+require_once 'vendor/autoload.php';
 
-// AWS access info
-if (!defined('awsAccessKey')) define('awsAccessKey', 'change-this');
-if (!defined('awsSecretKey')) define('awsSecretKey', 'change-this');
+// File to upload, we'll use this file since it exists
+list($uploadFile) = get_included_files();
 
+$bucketName = uniqid('s3test', false); // Temporary bucket
 
-// Check for CURL
-if (!extension_loaded('curl') && !@dl(PHP_SHLIB_SUFFIX == 'so' ? 'curl.so' : 'php_curl.dll'))
-	exit("\nERROR: CURL extension not loaded\n\n");
-
-// Pointless without your keys!
-if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
-	exit("\nERROR: AWS access information required\n\nPlease edit the following lines in this file:\n\n".
-	"define('awsAccessKey', 'change-me');\ndefine('awsSecretKey', 'change-me');\n\n");
-
-
-S3::setAuth(awsAccessKey, awsSecretKey);
+// Initialise S3
+S3::Init(
+        new Credentials(_getenv('ACCESS_KEY'), _getenv('SECRET_KEY')),
+        _getenv('REGION', 'us-west-1')
+    );
 
 
 function test_createDistribution($bucket, $cnames = array()) {
@@ -36,7 +30,7 @@ function test_createDistribution($bucket, $cnames = array()) {
 
 function test_listDistributions() {
 	if (($dists = S3::listDistributions()) !== false) {
-		if (sizeof($dists) == 0) echo "listDistributions(): No distributions\n";
+		if (count($dists) === 0) echo "listDistributions(): No distributions\n";
 		foreach ($dists as $dist) {
 			var_dump($dist);
 		}
@@ -63,7 +57,7 @@ function test_deleteDistribution($distributionId) {
 	// To delete a distribution configuration you must first set enable=false with
 	// the updateDistrubution() method and wait for status=Deployed:
 	if (($dist = S3::getDistribution($distributionId)) !== false) {
-		if ($dist['status'] == 'Deployed') {
+		if ($dist['status'] === 'Deployed') {
 			echo "deleteDistribution($distributionId): "; var_dump(S3::deleteDistribution($dist));
 		} else {
 			echo "deleteDistribution($distributionId): Distribution not ready for deletion (status is not 'Deployed')\n";

--- a/example-custom-endpoint.php
+++ b/example-custom-endpoint.php
@@ -1,0 +1,52 @@
+#!/usr/local/bin/php
+<?php
+/**
+ * $Id$
+ *
+ * S3 class usage
+ */
+
+require_once 'vendor/autoload.php';
+
+// File to upload, we'll use this file since it exists
+list($uploadFile) = get_included_files();
+
+$region = _getenv('REGION');
+
+$endpoint = new EndpointConfig(_getenv('ENDPOINT'), $region);
+$endpoint
+    ->withPathStyleEnabled(_getenv('USE_PATH_STYLE', 'YES') === 'YES')
+    ->withSSLEnabled(_getenv('USE_SSL', 'NO') === 'YES');
+
+$creds = new Credentials(_getenv('ACCESS_KEY'), _getenv('SECRET_KEY'));
+
+$bucketName = _getenv('BUCKET');
+
+// Initialise S3
+S3::Init($creds, $region, $endpoint);
+
+// Put our file (also with public read access)
+echo "S3::putObjectFile(): Copying {$uploadFile} to {$bucketName}/" . baseName($uploadFile) . PHP_EOL;
+if (S3::putObjectFile($uploadFile, $bucketName, baseName($uploadFile), S3::ACL_PUBLIC_READ)) {
+	echo "S3::putObjectFile(): File copied to {$bucketName}/" . baseName($uploadFile) . PHP_EOL;
+
+
+	// Get object info
+	$info = S3::getObjectInfo($bucketName, baseName($uploadFile));
+	echo "S3::getObjectInfo(): Info for {$bucketName}/" . baseName($uploadFile) . ': ' . print_r($info, 1);
+
+
+	// You can also fetch the object into memory
+    var_dump("S3::getObject() to memory", S3::getObject($bucketName, baseName($uploadFile)));
+
+
+	// Delete our file
+	if (S3::deleteObject($bucketName, baseName($uploadFile))) {
+		echo "S3::deleteObject(): Deleted file\n";
+	} else {
+		echo "S3::deleteObject(): Failed to delete file\n";
+	}
+} else {
+	echo "S3::putObjectFile(): Failed to copy file\n";
+}
+

--- a/example-form.php
+++ b/example-form.php
@@ -5,25 +5,18 @@
 * S3 form upload example
 */
 
-if (!class_exists('S3')) require_once 'S3.php';
+require_once 'vendor/autoload.php';
 
-// AWS access info
-if (!defined('awsAccessKey')) define('awsAccessKey', 'change-this');
-if (!defined('awsSecretKey')) define('awsSecretKey', 'change-this');
+// File to upload, we'll use this file since it exists
+list($uploadFile) = get_included_files();
 
-// Check for CURL
-if (!extension_loaded('curl') && !@dl(PHP_SHLIB_SUFFIX == 'so' ? 'curl.so' : 'php_curl.dll'))
-	exit("\nERROR: CURL extension not loaded\n\n");
+// Initialise S3
+S3::Init(
+	new Credentials(_getenv('ACCESS_KEY'), _getenv('SECRET_KEY')),
+	_getenv('REGION', 'us-west-1')
+);
 
-// Pointless without your keys!
-if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
-	exit("\nERROR: AWS access information required\n\nPlease edit the following lines in this file:\n\n".
-	"define('awsAccessKey', 'change-me');\ndefine('awsSecretKey', 'change-me');\n\n");
-
-
-S3::setAuth(awsAccessKey, awsSecretKey);
-
-$bucket = 'upload-bucket';
+$bucket = _getenv('BUCKET_NAME', 'upload-bucket');
 $path = 'myfiles/'; // Can be empty ''
 
 $lifetime = 3600; // Period for which the parameters are valid

--- a/example-helpers.php
+++ b/example-helpers.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * example-helpers.php
+ */
+
+/**
+ * Get value from environment
+ *
+ * @param string $name
+ * @param string|null $default_value
+ * @return string
+ */
+function _getenv($name, $default_value = null)
+{
+	$value = getenv($name);
+	if ($value !== false) {
+		return $value;
+	}
+
+	if ($default_value === null) {
+		throw new RuntimeException("$name not found in environment");
+	}
+
+	return $default_value;
+}

--- a/example-wrapper.php
+++ b/example-wrapper.php
@@ -6,54 +6,40 @@
 * Note: Although this wrapper works, it would be more efficient to use the S3 class instead
 */
 
-if (!class_exists('S3')) require_once 'S3.php';
-
-// AWS access info
-if (!defined('awsAccessKey')) define('awsAccessKey', 'change-this');
-if (!defined('awsSecretKey')) define('awsSecretKey', 'change-this');
-
-// Check for CURL
-if (!extension_loaded('curl') && !@dl(PHP_SHLIB_SUFFIX == 'so' ? 'curl.so' : 'php_curl.dll'))
-	exit("\nERROR: CURL extension not loaded\n\n");
-
-// Pointless without your keys!
-if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
-	exit("\nERROR: AWS access information required\n\nPlease edit the following lines in this file:\n\n".
-	"define('awsAccessKey', 'change-me');\ndefine('awsSecretKey', 'change-me');\n\n");
-
-
-################################################################################
+require_once 'vendor/autoload.php';
 
 
 final class S3Wrapper extends S3 {
 	private $position = 0, $mode = '', $buffer;
 
+	private $url;
+
 	public function url_stat($path, $flags) {
-		self::__getURL($path);
+		$this->__getURL($path);
 		return (($info = self::getObjectInfo($this->url['host'], $this->url['path'])) !== false) ?
 		array('size' => $info['size'], 'mtime' => $info['time'], 'ctime' => $info['time']) : false;
 	}
 
 	public function unlink($path) {
-		self::__getURL($path);
+		$this->__getURL($path);
 		return self::deleteObject($this->url['host'], $this->url['path']);
 	}
 
 	public function mkdir($path, $mode, $options) {
-		self::__getURL($path);
-		return self::putBucket($this->url['host'], self::__translateMode($mode));
+		$this->__getURL($path);
+		return self::putBucket($this->url['host'], $this->__translateMode($mode));
 	}
 
 	public function rmdir($path) {
-		self::__getURL($path);
+		$this->__getURL($path);
 		return self::deleteBucket($this->url['host']);
 	}
 
 	public function dir_opendir($path, $options) {
-		self::__getURL($path);
+		$this->__getURL($path);
 		if (($contents = self::getBucket($this->url['host'], $this->url['path'])) !== false) {
 			$pathlen = strlen($this->url['path']);
-			if (substr($this->url['path'], -1) == '/') $pathlen++;
+			if (substr($this->url['path'], -1) === '/') $pathlen++;
 			$this->buffer = array();
 			foreach ($contents as $file) {
 				if ($pathlen > 0) $file['name'] = substr($file['name'], $pathlen);
@@ -78,7 +64,7 @@ final class S3Wrapper extends S3 {
 	}
 
 	public function stream_close() {
-		if ($this->mode == 'w') {
+		if ($this->mode === 'w') {
 			self::putObject($this->buffer, $this->url['host'], $this->url['path']);
 		}
 		$this->position = 0;
@@ -105,9 +91,9 @@ final class S3Wrapper extends S3 {
 	public function stream_open($path, $mode, $options, &$opened_path) {
 		if (!in_array($mode, array('r', 'rb', 'w', 'wb'))) return false; // Mode not supported
 		$this->mode = substr($mode, 0, 1);
-		self::__getURL($path);
+		$this->__getURL($path);
 		$this->position = 0;
-		if ($this->mode == 'r') {
+		if ($this->mode === 'r') {
 			if (($this->buffer = self::getObject($this->url['host'], $this->url['path'])) !== false) {
 				if (is_object($this->buffer->body)) $this->buffer->body = (string)$this->buffer->body;
 			} else return false;
@@ -142,7 +128,7 @@ final class S3Wrapper extends S3 {
 	public function stream_seek($offset, $whence) {
 		switch ($whence) {
 			case SEEK_SET:
-                if ($offset < strlen($this->buffer->body) && $offset >= 0) {
+                if ($offset >= 0 && $offset < strlen($this->buffer->body)) {
                     $this->position = $offset;
                     return true;
                 } else return false;
@@ -180,16 +166,21 @@ final class S3Wrapper extends S3 {
 			$acl = self::ACL_PUBLIC_READ; //$acl = self::ACL_PUBLIC_READ_WRITE;
 		return $acl;
 	}
-} stream_wrapper_register('s3', 'S3Wrapper');
+}
+
+stream_wrapper_register('s3', 'S3Wrapper');
 
 
 ################################################################################
 
 
-S3::setAuth(awsAccessKey, awsSecretKey);
+$bucketName = uniqid('s3test', false); // Temporary bucket
 
-
-$bucketName = uniqid('s3test');
+// Initialise S3
+S3::Init(
+	new Credentials(_getenv('ACCESS_KEY'), _getenv('SECRET_KEY')),
+	_getenv('REGION', 'us-west-1')
+);
 
 echo "Creating bucket: {$bucketName}\n";
 var_dump(mkdir("s3://{$bucketName}"));

--- a/example.php
+++ b/example.php
@@ -6,98 +6,82 @@
 * S3 class usage
 */
 
-if (!class_exists('S3')) require_once 'S3.php';
+require_once 'vendor/autoload.php';
 
-// AWS access info
-if (!defined('awsAccessKey')) define('awsAccessKey', 'change-this');
-if (!defined('awsSecretKey')) define('awsSecretKey', 'change-this');
+// File to upload, we'll use this file since it exists
+list($uploadFile) = get_included_files();
 
-$uploadFile = dirname(__FILE__).'/S3.php'; // File to upload, we'll use the S3 class since it exists
-$bucketName = uniqid('s3test'); // Temporary bucket
+$bucketName = uniqid('s3test', false); // Temporary bucket
 
-// If you want to use PECL Fileinfo for MIME types:
-//if (!extension_loaded('fileinfo') && @dl('fileinfo.so')) $_ENV['MAGIC'] = '/usr/share/file/magic';
-
-
-// Check if our upload file exists
-if (!file_exists($uploadFile) || !is_file($uploadFile))
-	exit("\nERROR: No such file: $uploadFile\n\n");
-
-// Check for CURL
-if (!extension_loaded('curl') && !@dl(PHP_SHLIB_SUFFIX == 'so' ? 'curl.so' : 'php_curl.dll'))
-	exit("\nERROR: CURL extension not loaded\n\n");
-
-// Pointless without your keys!
-if (awsAccessKey == 'change-this' || awsSecretKey == 'change-this')
-	exit("\nERROR: AWS access information required\n\nPlease edit the following lines in this file:\n\n".
-	"define('awsAccessKey', 'change-me');\ndefine('awsSecretKey', 'change-me');\n\n");
-
-// Instantiate the class
-$s3 = new S3(awsAccessKey, awsSecretKey);
+// Initialise S3
+S3::Init(
+	new Credentials(_getenv('ACCESS_KEY'), _getenv('SECRET_KEY')),
+	_getenv('REGION', 'us-west-1')
+);
 
 // List your buckets:
-echo "S3::listBuckets(): ".print_r($s3->listBuckets(), 1)."\n";
+echo "S3::listBuckets(): ".print_r(S3::listBuckets(), 1)."\n";
 
 
 // Create a bucket with public read access
-if ($s3->putBucket($bucketName, S3::ACL_PUBLIC_READ)) {
+if (S3::putBucket($bucketName, S3::ACL_PUBLIC_READ)) {
 	echo "Created bucket {$bucketName}".PHP_EOL;
 
 	// Put our file (also with public read access)
-	if ($s3->putObjectFile($uploadFile, $bucketName, baseName($uploadFile), S3::ACL_PUBLIC_READ)) {
+	if (S3::putObjectFile($uploadFile, $bucketName, baseName($uploadFile), S3::ACL_PUBLIC_READ)) {
 		echo "S3::putObjectFile(): File copied to {$bucketName}/".baseName($uploadFile).PHP_EOL;
 
 
 		// Get the contents of our bucket
-		$contents = $s3->getBucket($bucketName);
+		$contents = S3::getBucket($bucketName);
 		echo "S3::getBucket(): Files in bucket {$bucketName}: ".print_r($contents, 1);
 
 
 		// Get object info
-		$info = $s3->getObjectInfo($bucketName, baseName($uploadFile));
+		$info = S3::getObjectInfo($bucketName, baseName($uploadFile));
 		echo "S3::getObjectInfo(): Info for {$bucketName}/".baseName($uploadFile).': '.print_r($info, 1);
 
 
 		// You can also fetch the object into memory
-		// var_dump("S3::getObject() to memory", $s3->getObject($bucketName, baseName($uploadFile)));
+		// var_dump("S3::getObject() to memory", S3::getObject($bucketName, baseName($uploadFile)));
 
 		// Or save it into a file (write stream)
-		// var_dump("S3::getObject() to savefile.txt", $s3->getObject($bucketName, baseName($uploadFile), 'savefile.txt'));
+		// var_dump("S3::getObject() to savefile.txt", S3::getObject($bucketName, baseName($uploadFile), 'savefile.txt'));
 
 		// Or write it to a resource (write stream)
-		// var_dump("S3::getObject() to resource", $s3->getObject($bucketName, baseName($uploadFile), fopen('savefile.txt', 'wb')));
+		// var_dump("S3::getObject() to resource", S3::getObject($bucketName, baseName($uploadFile), fopen('savefile.txt', 'wb')));
 
 
 
 		// Get the access control policy for a bucket:
-		// $acp = $s3->getAccessControlPolicy($bucketName);
+		// $acp = S3::getAccessControlPolicy($bucketName);
 		// echo "S3::getAccessControlPolicy(): {$bucketName}: ".print_r($acp, 1);
 
 		// Update an access control policy ($acp should be the same as the data returned by S3::getAccessControlPolicy())
-		// $s3->setAccessControlPolicy($bucketName, '', $acp);
-		// $acp = $s3->getAccessControlPolicy($bucketName);
+		// S3::setAccessControlPolicy($bucketName, '', $acp);
+		// $acp = S3::getAccessControlPolicy($bucketName);
 		// echo "S3::getAccessControlPolicy(): {$bucketName}: ".print_r($acp, 1);
 
 
 		// Enable logging for a bucket:
-		// $s3->setBucketLogging($bucketName, 'logbucket', 'prefix');
+		// S3::setBucketLogging($bucketName, 'logbucket', 'prefix');
 
-		// if (($logging = $s3->getBucketLogging($bucketName)) !== false) {
+		// if (($logging = S3::getBucketLogging($bucketName)) !== false) {
 		// 	echo "S3::getBucketLogging(): Logging for {$bucketName}: ".print_r($contents, 1);
 		// } else {
 		// 	echo "S3::getBucketLogging(): Logging for {$bucketName} not enabled\n";
 		// }
 
 		// Disable bucket logging:
-		// var_dump($s3->disableBucketLogging($bucketName));
+		// var_dump(S3::disableBucketLogging($bucketName));
 
 
 		// Delete our file
-		if ($s3->deleteObject($bucketName, baseName($uploadFile))) {
+		if (S3::deleteObject($bucketName, baseName($uploadFile))) {
 			echo "S3::deleteObject(): Deleted file\n";
 
 			// Delete the bucket we created (a bucket has to be empty to be deleted)
-			if ($s3->deleteBucket($bucketName)) {
+			if (S3::deleteBucket($bucketName)) {
 				echo "S3::deleteBucket(): Deleted bucket {$bucketName}\n";
 			} else {
 				echo "S3::deleteBucket(): Failed to delete bucket (it probably isn't empty)\n";


### PR DESCRIPTION
Most part of the change is to reduce global state, while keeping the API as close to original as possible. Please note that there are breaking changes, but I hope you will find them OK to live with.

I have also taken the liberty of adding a license file to match what is mentioned in `composer.json` and `S3.php`, and I have also added my employer to the list of copyrights, considering the amount of changes and the time spent doing them.

There are some tweaks to make examples work better with composer's autoloading. Also changes to those examples to make it load values through environment variables rather than having to edit the files.

I have tested these as much as I can against S3 and an in house implementation of S3 like storage access layer.