### PR TITLE
{} is deprecated, used [] instead

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2511,7 +2511,7 @@ final class S3Request
 			elseif ($header == 'content-type')
 				$this->response->headers['type'] = $value;
 			elseif ($header == 'etag')
-				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
+				$this->response->headers['hash'] = $value[0] == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
 				$this->response->headers[$header] = $value;
 		}


### PR DESCRIPTION
Accessing string characters with {} is deprecated, use [] instead