### PR TITLE
Deprecated fix for php 8.3.x

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2007,11 +2007,11 @@ class S3
 			$combinedHeaders[strtolower($k)] = trim($v);
 		foreach ($amzHeaders as $k => $v) 
 			$combinedHeaders[strtolower($k)] = trim($v);
-		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));
+		uksort($combinedHeaders, array(self::class, '__sortMetaHeadersCmp'));
 
 		// Convert null query string parameters to strings and sort
 		$parameters = array_map('strval', $parameters); 
-		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
+		uksort($parameters, array(self::class, '__sortMetaHeadersCmp'));
 		$queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
 
 		// Payload


### PR DESCRIPTION
fix deprecated issue in php 8.3.x 
"Deprecated: Use of "self" in callables is deprecated"